### PR TITLE
Fixed config "item" dependency

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -57,7 +57,9 @@ local function GetPlayerAppPerms()
                 searches = #app.bannedJobs
             end
 
-            for i = 1, #app.item do
+            local count = #app.item
+            if count == 0 then count = 1 end
+            for i = 1, count do
                 if haveItem(app.item[i]) or not app.item[i] then
                     if searches > 0 then
                         for k = 1, searches do


### PR DESCRIPTION
I noticed that apps do not display when "default" is false and an item is not declared within the config file. Based on the previous code, if the number of items is zero than the loop will not execute. This ensures that it will execute at least once.