### PR TITLE
Fixed boosting queue "404 Error"

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -44,7 +44,9 @@ function HasAppAccess(src, app)
     else
         searches = #v.bannedJobs
     end
-    for i = 1, #v.item do
+    local count = #v.item
+    if count == 0 then count = 1 end
+    for i = 1, count do
         if not v.item[i] or haveItem(PlayerData.items, v.item[i]) then
             if searches > 0 then
                 for k = 1, searches do


### PR DESCRIPTION
My last PR solved the item dependency issue, but also created a new problem. If an item isn't declared for boosting, the player will receive an error notification after attempting to join the queue. More or less, this is the same fix as last time but for server-side.