### PR TITLE
Bring back carboosting commands

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -37,6 +37,7 @@ local Translations = {
             player_offline = "Player not online.",
             not_inqueue = "Player not in boost queue!",
             incorrect_format = "ID Format Incorrect (must be a number)",
+            missingarg = "You forgot an argument!",
             command_tier_desc = "Sets the player's boosting Tier"
         },
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -22,6 +22,22 @@ local Translations = {
             bought_boost = "Bought boost",
             rewardboost = "Finished boost",
         },
+        command = {
+            command_desc = "Give a boost to a player",
+            command_name_ID = "ID",
+            command_help_ID = "Player ID",
+            command_name_tier = "Tier",
+            command_help_tier = "D/C/B/A/A+/S/S+",
+            command_name_vehicle = "Vehicle",
+            command_help_vehicle = "vehicles's name",
+            incorrect_type = "Incorrect type",
+            incorrect_vehicle = "Incorrect Vehicle",
+            incorrect_tier = "Incorrect Tier",
+            created = "Boost created",
+            player_offline = "Player not online.",
+            not_inqueue = "Player not in boost queue!",
+            incorrect_format = "ID Format Incorrect (must be a number)",
+        },
 
         laptop = {
             boosting = {

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -37,6 +37,7 @@ local Translations = {
             player_offline = "Player not online.",
             not_inqueue = "Player not in boost queue!",
             incorrect_format = "ID Format Incorrect (must be a number)",
+            command_tier_desc = "Sets the player's boosting Tier"
         },
 
         laptop = {

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -22,6 +22,22 @@ local Translations = {
             bought_boost = "Acheté un boost",
             rewardboost = "Finis un boost",
         },
+        command = {
+            command_desc = "Donne un contrat à un joueur",
+            command_name_ID = 'ID',
+            command_help_ID = 'ID Joueur',
+            command_name_tier = 'Tier',
+            command_help_tier = 'D/C/B/A/A+/S/S+',
+            command_name_vehicle = "Véhicule",
+            command_help_vehicle = 'Nom du véhicule',
+            incorrect_type = "Type incorrect",
+            incorrect_vehicle = "Véhicule incorrect",
+            incorrect_tier = "Tier incorrect",
+            created = "Boost créé",
+            player_offline = "Joueur introuvable",
+            not_inqueue = "Le joueur n'est pas dans la queue!",
+            incorrect_format = "Format d'ID Incorrect (doit être un nombre)",
+        },
 
         laptop = {
             boosting = {

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -37,6 +37,7 @@ local Translations = {
             player_offline = "Joueur introuvable",
             not_inqueue = "Le joueur n'est pas dans la queue!",
             incorrect_format = "Format d'ID Incorrect (doit être un nombre)",
+            command_tier_desc = "Défini le Tier du joueur"
         },
 
         laptop = {

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -37,6 +37,7 @@ local Translations = {
             player_offline = "Joueur introuvable",
             not_inqueue = "Le joueur n'est pas dans la queue!",
             incorrect_format = "Format d'ID Incorrect (doit être un nombre)",
+            missingarg = "Vous avez oublié un argument!",
             command_tier_desc = "Défini le Tier du joueur"
         },
 

--- a/server/boosting.lua
+++ b/server/boosting.lua
@@ -176,7 +176,11 @@ QBCore.Functions.CreateCallback('jl-laptop:server:CanStartBoosting', function(so
 
     if currentRuns[CID] then return cb("running") end
     if not currentContracts[CID][id] then return cb("notfound") end
-    if Config.RenewedPhone and not exports['qb-phone']:hasEnough(src, "gne", currentContracts[CID][id].cost) then return cb("notenough") end
+    if Config.RenewedPhone and not exports['qb-phone']:hasEnough(src, "gne", currentContracts[CID][id].cost) then
+        return cb("notenough")
+    elseif Player.PlayerData.money.crypto < currentContracts[CID][id].cost then
+        return cb("notenough")
+    end
     local amount = 0
     if cops == Config.Boosting.MinCops then
         amount = 1

--- a/server/boosting.lua
+++ b/server/boosting.lua
@@ -674,15 +674,16 @@ local function calcPrice(tier, type)
     return Config.Boosting.Debug and 0 or price
 end
 
-local function generateContract(src)
+local function generateContract(src, contract, vehicle, mission)
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
     local CID = Player.PlayerData.citizenid
     if not currentContracts[CID] then currentContracts[CID] = {} end
 
-    local contract = generateTier(src)
-    local vehicle = generateCar(contract)
-    local mission = missionType(Player, contract)
+    contract = contract or generateTier(src)
+    vehicle = vehicle or generateCar(contract)
+    mission = mission or missionType(Player, contract)
+
     if contract and vehicle and mission then
         currentContracts[CID][#currentContracts[CID]+1] = {
             id = #currentContracts[CID]+1,

--- a/server/boosting.lua
+++ b/server/boosting.lua
@@ -784,3 +784,18 @@ QBCore.Commands.Add('giveboost', Lang:t('boosting.command.command_desc'), {{ nam
         TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.incorrect_format'), "error", 5000)
     end
 end, "god")
+
+QBCore.Commands.Add('settier', Lang:t('boosting.command.command_tier_desc'), {{ name = Lang:t('boosting.command.command_name_ID'), help = Lang:t('boosting.command.command_help_ID')}, { name = Lang:t('boosting.command.command_name_tier'), help = Lang:t('boosting.command.command_help_tier')} }, false, function(source, args)
+    if args and type(tonumber(args[1])) == "number" then
+        local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
+        if Player then
+            local rep = Player.PlayerData.metadata["carboostrep"] or 0
+            rep = Config.Boosting.TiersPerRep[args[2]]
+            Player.Functions.SetMetaData('carboostrep', rep)
+        else
+            TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.player_offline'), 'error', 5000)
+        end
+    else
+        TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.incorrect_format'), "error", 5000)
+    end
+end, "god")

--- a/server/boosting.lua
+++ b/server/boosting.lua
@@ -756,3 +756,30 @@ AddEventHandler('playerDropped', function()
     end
 end)
 
+-- Commands --
+QBCore.Commands.Add('giveboost', Lang:t('boosting.command.command_desc'), {{ name = Lang:t('boosting.command.command_name_ID'), help = Lang:t('boosting.command.command_help_ID')}, { name = Lang:t('boosting.command.command_name_tier'), help = Lang:t('boosting.command.command_help_tier')}, { name = Lang:t('boosting.command.command_name_vehicle'), help = Lang:t('boosting.command.command_help_vehicle')}, { name = 'Type', help = 'boosting/vinscratch'}, }, false, function(source, args)
+    if args and type(tonumber(args[1])) == "number" then
+        local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
+        if Player then
+            local CID = Player.PlayerData.citizenid
+            if LookingForContracts[CID] then
+                if args[4] and not (args[4] == 'boosting' or args[4] == 'vinscratch') then
+                    TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.incorrect_type'), 'error', 7500)
+                elseif args[3] and not type(args[3]) == "string" then
+                    TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.incorrect_vehicle'), 'error', 7500)
+                elseif args[2] and not (args[2] == "D" or args[2] == "C" or args[2] == "B" or args[2] == "A" or args[2] == "A+" or args[2] == "S" or args[2] == "S+") then
+                    TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.incorrect_tier'), 'error', 7500)
+                else
+                    generateContract(tonumber(args[1]), args[2], args[3], args[4])
+                    TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.created'), 'success', 7500)
+                end
+            else
+                TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.not_inqueue'), 'error', 5000)
+            end
+        else
+            TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.player_offline'), 'error', 5000)
+        end
+    else
+        TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.incorrect_format'), "error", 5000)
+    end
+end, "god")

--- a/server/boosting.lua
+++ b/server/boosting.lua
@@ -787,13 +787,17 @@ end, "god")
 
 QBCore.Commands.Add('settier', Lang:t('boosting.command.command_tier_desc'), {{ name = Lang:t('boosting.command.command_name_ID'), help = Lang:t('boosting.command.command_help_ID')}, { name = Lang:t('boosting.command.command_name_tier'), help = Lang:t('boosting.command.command_help_tier')} }, false, function(source, args)
     if args and type(tonumber(args[1])) == "number" then
-        local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
-        if Player then
-            local rep = Player.PlayerData.metadata["carboostrep"] or 0
-            rep = Config.Boosting.TiersPerRep[args[2]]
-            Player.Functions.SetMetaData('carboostrep', rep)
+         if args[2] and type(tonumber(args[2])) == "string" then
+            local Player = QBCore.Functions.GetPlayer(tonumber(args[1]))
+            if Player then
+                local rep = Player.PlayerData.metadata["carboostrep"] or 0
+                rep = Config.Boosting.TiersPerRep[args[2]]
+                Player.Functions.SetMetaData('carboostrep', rep)
+            else
+                TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.player_offline'), 'error', 5000)
+            end
         else
-            TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.player_offline'), 'error', 5000)
+            TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.missingarg'), "error", 5000)
         end
     else
         TriggerClientEvent('QBCore:Notify', source, Lang:t('boosting.command.incorrect_format'), "error", 5000)


### PR DESCRIPTION
Give boost:
Requires the receiver to be in queue.
Arguments are optionnal if not specified it just generates it like the queue would
